### PR TITLE
NativeWrapper + MemUtils changes (preview/proposal)

### DIFF
--- a/LibSWBF2.NET.Test/Program.cs
+++ b/LibSWBF2.NET.Test/Program.cs
@@ -23,8 +23,8 @@ namespace LibSWBF2.NET.Test
                 };
 
                 Console.WriteLine("Loading... This might take a while...");
-                Level level = Level.FromFile(@"F:\SteamLibrary\steamapps\common\Star Wars Battlefront II\GameData\data\_lvl_pc\geo\geo1.lvl");
-                //Level level = Level.FromFile(@"/Users/will/Desktop/MLC.lvl");
+                //Level level = Level.FromFile(@"F:\SteamLibrary\steamapps\common\Star Wars Battlefront II\GameData\data\_lvl_pc\geo\geo1.lvl");
+                Level level = Level.FromFile(@"/Users/will/Desktop/MLC.lvl");
 
                 Console.WriteLine("Is World Level: " + level.IsWorldLevel);
                 Console.WriteLine("Models:");
@@ -36,7 +36,7 @@ namespace LibSWBF2.NET.Test
                     lastModel = model;
                 }
 
-                //level.Delete();
+                level.Delete();
                 Console.WriteLine("Done!");
             }
 

--- a/LibSWBF2.NET/LibSWBF2.NET.csproj
+++ b/LibSWBF2.NET/LibSWBF2.NET.csproj
@@ -36,7 +36,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WIN32</DefineConstants>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -46,7 +46,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE;WIN32</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -76,6 +76,7 @@
     <Compile Include="Wrappers\Level.cs" />
     <Compile Include="Wrappers\NativeWrapper.cs" />
     <Compile Include="Wrappers\Model.cs" />
+    <Compile Include="Utils\MarshalingUtils.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/LibSWBF2.NET/Utils/MarshalingUtils.cs
+++ b/LibSWBF2.NET/Utils/MarshalingUtils.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Runtime.InteropServices.WindowsRuntime;
+using LibSWBF2.Wrappers;
+
+namespace LibSWBF2.Utils
+{
+    class MemUtils {
+
+
+        public static T[] IntPtrsToWrappers<T>(IntPtr nativePtr, int count) where T : NativeWrapper, new()
+        {
+            if (nativePtr == IntPtr.Zero) return new T[0];
+
+            T[] wrappers = new T[count];
+            IntPtr[] ptrArr = new IntPtr[count];
+            Marshal.Copy(nativePtr, ptrArr, 0, count);
+            
+            for (int i = 0; i < count; i++){
+                wrappers[i] = new T();
+                wrappers[i].SetPtr(ptrArr[i]);
+            }
+
+            return wrappers;
+        }
+        
+
+        public static List<string> ptrToStringList(IntPtr nativePtr, int count)
+        {
+            List<string> strings = new List<string>();
+            IntPtr[] stringPtrs = new IntPtr[count];
+            Marshal.Copy(nativePtr, stringPtrs, 0, count);
+
+            for (int i = 0; i < count; i++)
+            {
+                strings.Add(Marshal.PtrToStringAnsi(stringPtrs[i]));
+            }
+
+            return strings;
+        }
+    }
+}

--- a/LibSWBF2.NET/Wrappers/Level.cs
+++ b/LibSWBF2.NET/Wrappers/Level.cs
@@ -1,4 +1,5 @@
 ﻿using LibSWBF2.Logging;
+using LibSWBF2.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -74,14 +75,12 @@ namespace LibSWBF2.Wrappers
         public Model[] GetModels()
         {
             APIWrapper.Level_GetModels(NativeInstance, out IntPtr modelArr, out uint modelCount);
-            IntPtr[] modelPtrs= new IntPtr[modelCount];
-            Marshal.Copy(modelArr, modelPtrs, 0, (int)modelCount);
-
-            Model[] models = new Model[modelCount];
-            for (int i = 0; i < modelCount; i++)
+            
+            Model[] models = MemUtils.IntPtrsToWrappers<Model>(modelArr, (int) modelCount);
+            
+            foreach (Model model in models)
             {
-                models[i] = new Model(modelPtrs[i]);
-                Children.Add(new WeakReference<NativeWrapper>(models[i]));
+                Children.Add(new WeakReference<NativeWrapper>(model));                
             }
 
             return models;

--- a/LibSWBF2.NET/Wrappers/Model.cs
+++ b/LibSWBF2.NET/Wrappers/Model.cs
@@ -15,6 +15,8 @@ namespace LibSWBF2.Wrappers
 
         }
 
+        public Model() : base(IntPtr.Zero){}
+
         public string Name
         {
             get 

--- a/LibSWBF2.NET/Wrappers/NativeWrapper.cs
+++ b/LibSWBF2.NET/Wrappers/NativeWrapper.cs
@@ -24,5 +24,10 @@ namespace LibSWBF2.Wrappers
         {
             return NativeInstance != IntPtr.Zero;
         }
+
+        internal void SetPtr(IntPtr ptr)
+        {
+            NativeInstance = ptr;
+        }
     }
 }


### PR DESCRIPTION
I've written a bunch of C# wrappers for ```World```, ```Instance```, ```Segment```, etc in my branch used for LVL -> Unity importing.  There's a lot of code duplication when converting an ```IntPtr``` to a list of Wrappers, so I wrote a generic version in Utils/MarshalingUtils.cs.  However, this requires some changes to ```NativeWrapper``` and a _public_ parameterless constructor for each ```NativeWrapper``` subclass.  I wanted your input on this before using it with my other Wrapper classes...