### PR TITLE
Race condition fix (tellg, called in FileReader::GetPosition not thread safe) 

### DIFF
--- a/LibSWBF2.Test/CMakeLists.txt
+++ b/LibSWBF2.Test/CMakeLists.txt
@@ -19,10 +19,12 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 #SOURCES
-add_executable(lightsTest 	  testLights.cpp)
-add_executable(collisionTest  testCollision.cpp)
+add_executable(lightsTest 	       testLights.cpp)
+add_executable(collisionTest       testCollision.cpp)
+add_executable(basicContainerTest  testContainerBasic.cpp)
 
 
 #LINKING
-target_link_libraries(lightsTest     PUBLIC SWBF2)
-target_link_libraries(collisionTest  PUBLIC SWBF2)
+target_link_libraries(lightsTest     	  PUBLIC SWBF2)
+target_link_libraries(collisionTest    	  PUBLIC SWBF2)
+target_link_libraries(basicContainerTest  PUBLIC SWBF2)

--- a/LibSWBF2.Test/testContainerBasic.cpp
+++ b/LibSWBF2.Test/testContainerBasic.cpp
@@ -1,0 +1,64 @@
+#include "LibSWBF2.h"
+#include "FileWriter.h"
+#include "Chunks/LVL/LVL.h"
+#include "Types/Enums.h"
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+
+#include "fmt/core.h"
+#include "fmt/format.h"
+
+
+using LibSWBF2::Types::String;
+using LibSWBF2::Types::List;
+
+using namespace LibSWBF2::Chunks::LVL;
+using namespace LibSWBF2::Wrappers;
+
+using LibSWBF2::Container;
+using LibSWBF2::Logging::Logger;
+using LibSWBF2::Logging::LoggerEntry;
+
+
+#define COUT(x) std::cout << x << std::endl
+
+void libLog(const LoggerEntry* log){ COUT(log->ToString().Buffer()); }
+
+
+
+int main()
+{
+	Logger::SetLogCallback(&libLog);
+
+	const char *path1;
+	const char *path2;
+
+#ifdef __APPLE__
+	path1 = "/Users/will/Desktop/geo1.lvl";
+	path2 = "/Users/will/Desktop/MLC.lvl";
+#else
+	path1 = "/home/will/Desktop/geo1.lvl";
+	path2 = "/home/will/Desktop/MLC.lvl";
+#endif
+
+	Container *container = Container::Create();
+	auto handle1 = container -> AddLevel(path1);
+	auto handle2 = container -> AddLevel(path2);
+	container -> StartLoading();
+
+	while (!container -> IsDone())
+	{
+		usleep(100000);
+		std::cout << fmt::format("\rProgress1: {}%, Progress2: {}%", 
+								(int) (container -> GetLevelProgress(handle1) * 100.0f),
+								(int) (container -> GetLevelProgress(handle2) * 100.0f)).c_str()
+				  << std::flush;
+	}
+
+	std::cout << std::endl;
+	
+	return 0;
+}

--- a/LibSWBF2/Chunks/BaseChunk.cpp
+++ b/LibSWBF2/Chunks/BaseChunk.cpp
@@ -46,8 +46,6 @@ namespace LibSWBF2::Chunks
 		m_Header = stream.ReadChunkHeader(false);
 		m_Size = stream.ReadChunkSize();
 
-		stream.SetLatestChunkPosition(m_ChunkPosition);
-
 		LOG_INFO("Position: {}", m_ChunkPosition);
 		LOG_INFO("Header: {}", m_Header);
 		LOG_INFO("Size: {:#x}", m_Size);
@@ -226,4 +224,3 @@ namespace LibSWBF2::Chunks
 		return (float_t)m_ThreadHandling->m_CurrentReader->GetLatestChunkPosition() / (float_t)m_ThreadHandling->m_CurrentReader->GetFileSize();
 	}
 }
-

--- a/LibSWBF2/Chunks/BaseChunk.cpp
+++ b/LibSWBF2/Chunks/BaseChunk.cpp
@@ -46,6 +46,8 @@ namespace LibSWBF2::Chunks
 		m_Header = stream.ReadChunkHeader(false);
 		m_Size = stream.ReadChunkSize();
 
+		stream.SetLatestChunkPosition(m_ChunkPosition);
+
 		LOG_INFO("Position: {}", m_ChunkPosition);
 		LOG_INFO("Header: {}", m_Header);
 		LOG_INFO("Size: {:#x}", m_Size);
@@ -221,7 +223,7 @@ namespace LibSWBF2::Chunks
 			return 1.0f;
 		}
 
-		return (float_t)m_ThreadHandling->m_CurrentReader->GetPosition() / (float_t)m_ThreadHandling->m_CurrentReader->GetFileSize();
+		return (float_t)m_ThreadHandling->m_CurrentReader->GetLatestChunkPosition() / (float_t)m_ThreadHandling->m_CurrentReader->GetFileSize();
 	}
 }
 

--- a/LibSWBF2/FileReader.cpp
+++ b/LibSWBF2/FileReader.cpp
@@ -50,6 +50,8 @@ namespace LibSWBF2
 			{
 				m_Reader.seekg(pos);
 			}
+
+			m_LatestChunkPos = pos;
 		}
 		return value;
 	}
@@ -245,10 +247,5 @@ namespace LibSWBF2
 	size_t FileReader::GetLatestChunkPosition()
 	{
 		return m_LatestChunkPos;
-	}
-
-	void FileReader::SetLatestChunkPosition(size_t position)
-	{
-		m_LatestChunkPos = position;
 	}
 }

--- a/LibSWBF2/FileReader.cpp
+++ b/LibSWBF2/FileReader.cpp
@@ -9,7 +9,7 @@ namespace LibSWBF2
 
 	FileReader::FileReader()
 	{
-
+		m_LatestChunkPos = 0;
 	}
 
 	FileReader::~FileReader()
@@ -239,5 +239,16 @@ namespace LibSWBF2
 			return true;
 		}
 		return false;
+	}
+
+
+	size_t FileReader::GetLatestChunkPosition()
+	{
+		return m_LatestChunkPos;
+	}
+
+	void FileReader::SetLatestChunkPosition(size_t position)
+	{
+		m_LatestChunkPos = position;
 	}
 }

--- a/LibSWBF2/FileReader.h
+++ b/LibSWBF2/FileReader.h
@@ -29,10 +29,8 @@ namespace LibSWBF2
 		size_t GetFileSize();
 		bool SkipBytes(const size_t& Amount);
 		void Close();
-
+		
 		size_t GetLatestChunkPosition();
-		void SetLatestChunkPosition(size_t position);
-
 
 	private:
 		bool CheckGood(size_t ReadSize);

--- a/LibSWBF2/FileReader.h
+++ b/LibSWBF2/FileReader.h
@@ -2,6 +2,7 @@
 #include "Chunks/HeaderNames.h"
 #include "Types/LibString.h"
 #include <fstream>
+#include <atomic>
 
 namespace LibSWBF2
 {
@@ -28,11 +29,18 @@ namespace LibSWBF2
 		size_t GetFileSize();
 		bool SkipBytes(const size_t& Amount);
 		void Close();
+
+		size_t GetLatestChunkPosition();
+		void SetLatestChunkPosition(size_t position);
+
+
 	private:
 		bool CheckGood(size_t ReadSize);
 
 		size_t m_FileSize = 0;
 		Types::String m_FileName;
 		std::ifstream m_Reader;
+		
+		std::atomic_size_t m_LatestChunkPos;
 	};
 }


### PR DESCRIPTION
```tellg``` appears not to be thread safe.  I was unable to use ```GetLevelProgress``` reliably until I made sure ```GetPosition``` was only called on the file-reading thread.  IDK if my particular fix is best, but it solved my problems.

(files/changes other than ```FileReader```/```BasicChunk``` are just basic ```GetLevelProgress``` tests)