### PR TITLE
Collision API Updates

### DIFF
--- a/LibSWBF2.NET.Test/testCollision.cs
+++ b/LibSWBF2.NET.Test/testCollision.cs
@@ -23,9 +23,9 @@ namespace LibSWBF2.NET.Test
             
             //Level level = Level.FromFile(@"F:\SteamLibrary\steamapps\common\Star Wars Battlefront II\GameData\data\_lvl_pc\geo\geo1.lvl");
             //Level level = Level.FromFile(@"/Users/will/Desktop/MLC.lvl");
-            Level level = Level.FromFile(@"/home/will/Desktop/geo1.lvl");
             //Level level = Level.FromFile(@"/home/will/Desktop/geo1.lvl");
-            //Level level = Level.FromFile(@"/Users/will/Desktop/geo1.lvl");
+            //Level level = Level.FromFile(@"/home/will/Desktop/geo1.lvl");
+            Level level = Level.FromFile(@"/Users/will/Desktop/geo1.lvl");
 
             Model[] models = level.GetModels();
             foreach (Model model in models)

--- a/LibSWBF2.NET.Test/testCollision.cs
+++ b/LibSWBF2.NET.Test/testCollision.cs
@@ -35,8 +35,8 @@ namespace LibSWBF2.NET.Test
                 Console.WriteLine("\nModel: " + model.Name);
                 CollisionMesh mesh = model.GetCollisionMesh();
 
-                Console.WriteLine("\tNum collision indices:   " + mesh.GetIndices().Length.ToString());
-                Console.WriteLine("\tNum collision verticies: " + mesh.GetVertices().Length.ToString());
+                Console.WriteLine("\tNum collision indices:   {0}", mesh.GetIndices().Length);
+                Console.WriteLine("\tNum collision verticies: {0}", mesh.GetVertices().Length);
             
                 CollisionPrimitive[] prims = model.GetPrimitivesMasked();
 

--- a/LibSWBF2.NET.Test/testCollision.cs
+++ b/LibSWBF2.NET.Test/testCollision.cs
@@ -35,6 +35,15 @@ namespace LibSWBF2.NET.Test
 
                 Console.WriteLine("\tNum collision indices:   " + mesh.GetIndices().Length.ToString());
                 Console.WriteLine("\tNum collision verticies: " + mesh.GetVertices().Length.ToString());
+            
+                Console.WriteLine("\tPrimitives: ");
+
+                CollisionPrimitive[] prims = model.GetPrimitivesMasked();
+
+                foreach (var prim in prims)
+                {
+                    Console.WriteLine("\t\t{0}", prim.name);
+                }
             }
 
             Console.WriteLine("Done!");

--- a/LibSWBF2.NET.Test/testCollision.cs
+++ b/LibSWBF2.NET.Test/testCollision.cs
@@ -36,9 +36,9 @@ namespace LibSWBF2.NET.Test
                 Console.WriteLine("\tNum collision indices:   " + mesh.GetIndices().Length.ToString());
                 Console.WriteLine("\tNum collision verticies: " + mesh.GetVertices().Length.ToString());
             
-                Console.WriteLine("\tPrimitives: ");
-
                 CollisionPrimitive[] prims = model.GetPrimitivesMasked();
+
+                Console.WriteLine("\t{0} Primitives: ", prims.Length);
 
                 foreach (var prim in prims)
                 {

--- a/LibSWBF2.NET.Test/testCollision.cs
+++ b/LibSWBF2.NET.Test/testCollision.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using LibSWBF2.Logging;
+//using LibSWBF2.Logging;
 using LibSWBF2.Wrappers;
 
 namespace LibSWBF2.NET.Test
@@ -12,20 +12,22 @@ namespace LibSWBF2.NET.Test
     class Program
     {
         static void Main(string[] args)
-        {            
+        {    
+            /*        
             Logger.SetLogLevel(ELogType.Warning);
             Logger.OnLog += (LoggerEntry logEntry) => 
             {
                 Console.WriteLine(logEntry.ToString());
             };
+            */
 
             Console.WriteLine("Loading... This might take a while...");
             
             //Level level = Level.FromFile(@"F:\SteamLibrary\steamapps\common\Star Wars Battlefront II\GameData\data\_lvl_pc\geo\geo1.lvl");
             //Level level = Level.FromFile(@"/Users/will/Desktop/MLC.lvl");
             //Level level = Level.FromFile(@"/home/will/Desktop/geo1.lvl");
-            //Level level = Level.FromFile(@"/home/will/Desktop/geo1.lvl");
-            Level level = Level.FromFile(@"/Users/will/Desktop/geo1.lvl");
+            Level level = Level.FromFile(@"/home/will/Desktop/geo1.lvl");
+            //Level level = Level.FromFile(@"/Users/will/Desktop/geo1.lvl");
 
             Model[] models = level.GetModels();
             foreach (Model model in models)

--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -62,6 +62,10 @@ namespace LibSWBF2
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr Model_GetCollisionMesh(IntPtr model);
 
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Model_GetPrimitivesMasked(IntPtr NativeInstance, uint mask,
+                                                            out int numPrims, out IntPtr ptr);
+
 
 
         // CollisionMesh //
@@ -71,6 +75,17 @@ namespace LibSWBF2
         
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void CollisionMesh_GetVertexBuffer(IntPtr collMesh, out uint count, out IntPtr buffer);
+
+
+
+        // CollisionPrimitive //
+
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void CollisionPrimitive_FetchAllFields(IntPtr nativePtr,
+                                                    out float f1, out float f2, out float f3,
+                                                    out IntPtr name, out IntPtr parentName,
+                                                    out uint maskFlags, out uint primitiveType,
+                                                    out IntPtr pos, out IntPtr rot);
 
     }
 }

--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -15,6 +15,23 @@ namespace LibSWBF2
         public delegate void LogCallback(IntPtr LoggerEntryPtr);
 
 
+
+        // Vectors 
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Vector4_FromPtr(IntPtr ptr, out float x,
+                                                    out float y, out float z,
+                                                                 out float w);
+
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Vector3_FromPtr(IntPtr ptr, out float x,
+                                                    out float y, out float z);
+
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Vector2_FromPtr(IntPtr ptr, out float x,
+                                                              out float y);
+
+
+
         // Logging //
 
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]

--- a/LibSWBF2.NET/LibSWBF2.NET.csproj
+++ b/LibSWBF2.NET/LibSWBF2.NET.csproj
@@ -77,6 +77,8 @@
     <Compile Include="Wrappers\NativeWrapper.cs" />
     <Compile Include="Wrappers\Model.cs" />
     <Compile Include="Wrappers\CollisionMesh.cs" />
+    <Compile Include="Wrappers\CollisionPrimitive.cs" />
+    <Compile Include="Utils\MarshalingUtils.cs" />    
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/LibSWBF2.NET/Types/Vector2.cs
+++ b/LibSWBF2.NET/Types/Vector2.cs
@@ -7,5 +7,21 @@ namespace LibSWBF2.Types
     {
         public float X;
         public float Y;
+
+        public Vector2(IntPtr nativePtr)
+        {
+        	APIWrapper.Vector2_FromPtr(nativePtr, out X, out Y);
+        }
+
+        public Vector2(float val = 0)
+        {
+            X = 0.0f;
+            Y = 0.0f;
+        }
+
+        public override String ToString()
+        {
+            return "(" + X + ", " + Y + ")";
+        }
     }
 }

--- a/LibSWBF2.NET/Types/Vector3.cs
+++ b/LibSWBF2.NET/Types/Vector3.cs
@@ -8,5 +8,25 @@ namespace LibSWBF2.Types
         public float X;
         public float Y;
         public float Z;
+
+        public Vector3(IntPtr nativePtr)
+        {
+
+            if (nativePtr != IntPtr.Zero && nativePtr != null)
+            {
+                APIWrapper.Vector3_FromPtr(nativePtr, out X, out Y, out Z);
+            }
+            else 
+            {
+                X = 0.0f;
+                Y = 0.0f;
+                Z = 0.0f;
+            }
+        }
+
+        public override String ToString()
+        {
+            return "(" + X + ", " + Y + ", " + Z + ")";
+        }
     }
 }

--- a/LibSWBF2.NET/Types/Vector4.cs
+++ b/LibSWBF2.NET/Types/Vector4.cs
@@ -9,5 +9,15 @@ namespace LibSWBF2.Types
         public float Y;
         public float Z;
         public float W;
+
+        public Vector4(IntPtr nativePtr)
+        {
+        	APIWrapper.Vector4_FromPtr(nativePtr, out X, out Y, out Z, out W);
+        }
+
+        public override String ToString()
+        {
+            return "(" + X + ", " + Y + ", " + Z + ", " + W + ")";
+        }
     }
 }

--- a/LibSWBF2.NET/Utils/MarshalingUtils.cs
+++ b/LibSWBF2.NET/Utils/MarshalingUtils.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Runtime.InteropServices.WindowsRuntime;
+using LibSWBF2.Wrappers;
+
+namespace LibSWBF2.Utils
+{
+    class MemUtils {
+
+        public static T[] IntPtrToWrapperArray<T>(IntPtr nativePtr, int count) where T : NativeWrapper, new()
+        {
+            if (nativePtr == IntPtr.Zero) return new T[0];
+
+            T[] wrappers = new T[count];
+            IntPtr[] ptrArr = new IntPtr[count];
+            Marshal.Copy(nativePtr, ptrArr, 0, count);
+
+            for (int i = 0; i < count; i++){
+                wrappers[i] = new T();
+                wrappers[i].SetPtr(ptrArr[i]);
+            }
+
+            return wrappers;
+        }
+
+        public static List<string> IntPtrToStringList(IntPtr nativePtr, int count)
+        {
+            List<string> strings = new List<string>();
+            IntPtr[] stringPtrs = new IntPtr[count];
+            Marshal.Copy(nativePtr, stringPtrs, 0, count);
+
+            for (int i = 0; i < count; i++)
+            {
+                strings.Add(Marshal.PtrToStringAnsi(stringPtrs[i]));
+            }
+
+            return strings;
+        }
+    }
+}
+

--- a/LibSWBF2.NET/Wrappers/CollisionPrimitive.cs
+++ b/LibSWBF2.NET/Wrappers/CollisionPrimitive.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using LibSWBF2.Logging;
+
+namespace LibSWBF2.Wrappers
+{
+    public class CollisionPrimitive : NativeWrapper
+    {
+        public CollisionPrimitive() : base(IntPtr.Zero){}
+
+        internal override void SetPtr(IntPtr ptr)
+        {
+            NativeInstance = ptr;
+            APIWrapper.CollisionPrimitive_FetchAllFields(
+                NativeInstance, out f1, out f2, out f3,
+                out IntPtr namePtr, out IntPtr parentNamePtr,
+                out maskFlags, out primitiveType,
+                out IntPtr posPtr, out IntPtr rotPtr
+            );
+
+            rotation = new Vector4(rotPtr);
+            position = new Vector3(posPtr);
+
+            name = Marshal.PtrToStringAnsi(namePtr);
+            parentName = Marshal.PtrToStringAnsi(parentNamePtr);
+        }
+
+        public uint maskFlags;
+        public uint primitiveType;
+
+
+        public bool GetCubeDims(out float x, out float y, out float z)
+        {
+            if (primitiveType != 4) return false;
+
+            x = f1;
+            y = f2;
+            z = f3;
+            return true;
+        }
+
+        public bool GetCylinderDims(out float radius, out float height)
+        {
+            if (primitiveType != 2) return false;
+
+            radius = f1;
+            height = f2;
+            return true;
+        }
+
+        public bool GetSphereRadius(out float radius)
+        {
+            if (primitiveType != 1) return false;
+
+            radius = f1;
+            return true;
+        }
+
+        public Vector4 rotation;
+        public Vector3 position;
+
+        public string parentName, name;
+
+        private float f1, f2, f3;
+    }
+}

--- a/LibSWBF2.NET/Wrappers/CollisionPrimitive.cs
+++ b/LibSWBF2.NET/Wrappers/CollisionPrimitive.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
+
+using LibSWBF2.Types;
 using LibSWBF2.Logging;
 
 namespace LibSWBF2.Wrappers
@@ -35,29 +37,23 @@ namespace LibSWBF2.Wrappers
 
         public bool GetCubeDims(out float x, out float y, out float z)
         {
-            if (primitiveType != 4) return false;
-
             x = f1;
             y = f2;
             z = f3;
-            return true;
+            return primitiveType == 4;
         }
 
         public bool GetCylinderDims(out float radius, out float height)
         {
-            if (primitiveType != 2) return false;
-
             radius = f1;
             height = f2;
-            return true;
+            return primitiveType == 2;
         }
 
         public bool GetSphereRadius(out float radius)
         {
-            if (primitiveType != 1) return false;
-
             radius = f1;
-            return true;
+            return primitiveType == 1;
         }
 
         public Vector4 rotation;

--- a/LibSWBF2.NET/Wrappers/Level.cs
+++ b/LibSWBF2.NET/Wrappers/Level.cs
@@ -71,7 +71,7 @@ namespace LibSWBF2.Wrappers
         public Model[] GetModels()
         {
             APIWrapper.Level_GetModels(NativeInstance, out IntPtr modelArr, out uint modelCount);
-            IntPtr[] modelPtrs= new IntPtr[modelCount];
+            IntPtr[] modelPtrs = new IntPtr[modelCount];
             Marshal.Copy(modelArr, modelPtrs, 0, (int)modelCount);
 
             Model[] models = new Model[modelCount];

--- a/LibSWBF2.NET/Wrappers/Model.cs
+++ b/LibSWBF2.NET/Wrappers/Model.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
+
 using LibSWBF2.Logging;
+using LibSWBF2.Utils;
 
 namespace LibSWBF2.Wrappers
 {
@@ -60,5 +62,13 @@ namespace LibSWBF2.Wrappers
             if (!IsValid()) throw new Exception("Underlying native class is destroyed!");
             return new CollisionMesh(APIWrapper.Model_GetCollisionMesh(NativeInstance));            
         }
+
+        public CollisionPrimitive[] GetPrimitivesMasked(uint mask = 0xffffffff)
+        {
+            if (!IsValid()) throw new Exception("Underlying native class is destroyed!");
+            APIWrapper.Model_GetPrimitivesMasked(NativeInstance, mask, out int numPrims, out IntPtr ptr);
+            return MemUtils.IntPtrToWrapperArray<CollisionPrimitive>(ptr,numPrims);
+        }
+
     }
 }

--- a/LibSWBF2.NET/Wrappers/Model.cs
+++ b/LibSWBF2.NET/Wrappers/Model.cs
@@ -67,6 +67,7 @@ namespace LibSWBF2.Wrappers
         {
             if (!IsValid()) throw new Exception("Underlying native class is destroyed!");
             APIWrapper.Model_GetPrimitivesMasked(NativeInstance, mask, out int numPrims, out IntPtr ptr);
+            Console.WriteLine("\tNumPrims: {0}", numPrims);
             return MemUtils.IntPtrToWrapperArray<CollisionPrimitive>(ptr,numPrims);
         }
 

--- a/LibSWBF2.NET/Wrappers/Model.cs
+++ b/LibSWBF2.NET/Wrappers/Model.cs
@@ -69,7 +69,6 @@ namespace LibSWBF2.Wrappers
         {
             if (!IsValid()) throw new Exception("Underlying native class is destroyed!");
             APIWrapper.Model_GetPrimitivesMasked(NativeInstance, mask, out int numPrims, out IntPtr ptr);
-            Console.WriteLine("\tNumPrims: {0}", numPrims);
             return MemUtils.IntPtrToWrapperArray<CollisionPrimitive>(ptr,numPrims);
         }
 

--- a/LibSWBF2.NET/Wrappers/NativeWrapper.cs
+++ b/LibSWBF2.NET/Wrappers/NativeWrapper.cs
@@ -24,5 +24,10 @@ namespace LibSWBF2.Wrappers
         {
             return NativeInstance != IntPtr.Zero;
         }
+
+        internal virtual void SetPtr(IntPtr ptr)
+        {
+            NativeInstance = ptr;
+        }
     }
 }

--- a/LibSWBF2.Test/testCollision.cpp
+++ b/LibSWBF2.Test/testCollision.cpp
@@ -21,13 +21,13 @@ using LibSWBF2::Logging::LoggerEntry;
 
 #define COUT(x) std::cout << x << std::endl
 
-void libLog(const LoggerEntry* log){ COUT(log->ToString().Buffer()); }
+//void libLog(const LoggerEntry* log){ COUT(log->ToString().Buffer()); }
 
 
 
 int main()
 {
-	Logger::SetLogCallback(&libLog);
+	//Logger::SetLogCallback(&libLog);
 
 	const char *path;
 

--- a/LibSWBF2.Test/testContainerBasic.cpp
+++ b/LibSWBF2.Test/testContainerBasic.cpp
@@ -25,13 +25,13 @@ using LibSWBF2::Logging::LoggerEntry;
 
 #define COUT(x) std::cout << x << std::endl
 
-void libLog(const LoggerEntry* log){ COUT(log->ToString().Buffer()); }
+//void libLog(const LoggerEntry* log){ COUT(log->ToString().Buffer()); }
 
 
 
 int main()
 {
-	Logger::SetLogCallback(&libLog);
+	//Logger::SetLogCallback(&libLog);
 
 	const char *path1;
 	const char *path2;

--- a/LibSWBF2.Test/testLights.cpp
+++ b/LibSWBF2.Test/testLights.cpp
@@ -18,13 +18,13 @@ using LibSWBF2::Logging::LoggerEntry;
 
 #define COUT(x) std::cout << x << std::endl
 
-void libLog(const LoggerEntry* log){ COUT(log->ToString().Buffer()); }
+//void libLog(const LoggerEntry* log){ COUT(log->ToString().Buffer()); }
 
 
 
 int main()
 {
-	Logger::SetLogCallback(&libLog);
+	//Logger::SetLogCallback(&libLog);
 
 #ifdef __APPLE__
 	Level *testLVL = Level::FromFile("/Users/will/Desktop/MLC.lvl");

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -231,28 +231,28 @@ namespace LibSWBF2
                                             float_t& f1, float_t& f2, float_t& f3,
                                             const char *& namePtr, const char *& parentNamePtr,
                                             uint32_t& maskFlags, uint32_t& primitiveType,
-                                            const Vector3*& pos, const Vector4*& rot)
+                                            Vector3*& pos, Vector4*& rot)
     {
+    	static String name, parentName;
+    	static Vector3 posTemp;
+    	static Vector4 rotTemp;
+
     	f1 = f2 = f3 = 0.0f;
 
-    	COUT("Is null? " << (primPtr == nullptr));
-    	//COUT("Prim name: " << primPtr -> GetName().Buffer());
-
-    	const String& name = primPtr -> GetName();
-    	const String& parentName = primPtr -> GetParentName();
-
-    	COUT("Set namez");
+    	name = primPtr -> GetName();
+    	parentName = primPtr -> GetParentName();
 
     	namePtr = name.Buffer();
     	parentNamePtr = parentName.Buffer();
 
-    	COUT("Set name ptrs");
-
     	maskFlags = (uint32_t) primPtr -> GetMaskFlags();
     	primitiveType = (uint32_t) primPtr -> GetPrimitiveType();
 
-    	pos = &(primPtr -> GetPosition()); 
-    	rot = &(primPtr -> GetRotation()); 
+    	rotTemp = primPtr -> GetRotation();
+    	posTemp = primPtr -> GetPosition();
+
+    	pos = &posTemp; 
+    	rot = &rotTemp; 
 
     	switch (primitiveType)
     	{

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -157,6 +157,29 @@ namespace LibSWBF2
 	}
 
 
+	const void Model_GetPrimitivesMasked(const Model* model, uint32_t mask, int& numPrims,
+										CollisionPrimitive**& primArrayPtr)
+	{
+		static List<CollisionPrimitive> primsList;
+		static List<CollisionPrimitive *> primPtrs;
+		
+		numPrims = 0;
+		CheckPtr(model,);
+
+		primsList = model -> GetCollisionPrimitives((ECollisionMaskFlags) mask);
+		primPtrs.Clear();
+
+		for (size_t i = 0; i < primsList.Size(); ++i)
+		{
+			primPtrs.Add(&primsList[i]);
+		}		
+
+
+		primArrayPtr = primPtrs.GetArrayPtr();
+		numPrims = (uint32_t) primPtrs.Size();		
+	}
+
+
 	const void CollisionMesh_GetIndexBuffer(const CollisionMesh *collMesh, uint32_t& count, int*& outBuffer)
 	{
 		static int* tempBuffer = nullptr;
@@ -198,6 +221,43 @@ namespace LibSWBF2
 
     	buffer = tempBuffer;
     }
+
+
+    //CollisionPrimitive
+
+    const void CollisionPrimitive_FetchAllFields(CollisionPrimitive *primPtr,
+                                            float_t& f1, float_t& f2, float_t& f3,
+                                            const char *& name, const char *& parentName,
+                                            uint32_t& maskFlags, uint32_t& primitiveType,
+                                            const Vector3*& pos, const Vector4*& rot)
+    {
+    	f1 = f2 = f3 = 0.0f;
+
+    	name = primPtr -> GetName().Buffer();
+    	parentName = primPtr -> GetParentName().Buffer();
+
+    	maskFlags = (uint32_t) primPtr -> GetMaskFlags();
+    	primitiveType = (uint32_t) primPtr -> GetPrimitiveType();
+
+    	pos = &(primPtr -> GetPosition()); 
+    	rot = &(primPtr -> GetRotation()); 
+
+    	switch (primitiveType)
+    	{
+    		case 1:
+    			primPtr -> GetSphereRadius(f1);
+    			return;
+    		case 2:
+    			primPtr -> GetCylinderDims(f1,f2);
+    			return;
+    		case 4:
+    			primPtr -> GetCubeDims(f1,f2,f3);
+    			return;
+    		default:
+    			return;
+    	}
+    }
+
 
 
 

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -259,6 +259,30 @@ namespace LibSWBF2
     }
 
 
+    
+    const void Vector4_FromPtr(const Vector4* vec, float& x, float& y, float& z, float &w)
+    {
+    	x = vec -> m_X;
+    	y = vec -> m_Y;
+    	z = vec -> m_Z;
+       	w = vec -> m_W;
+    } 
+
+    const void Vector3_FromPtr(const Vector3* vec, float& x, float& y, float& z)
+    {
+    	x = vec -> m_X;
+    	y = vec -> m_Y;
+    	z = vec -> m_Z;
+    } 
+
+    const void Vector2_FromPtr(const Vector2* vec, float& x, float& y)
+    {
+    	x = vec -> m_X;
+    	y = vec -> m_Y;
+    } 
+
+
+
 
 
 	const char* ENUM_TopologyToString(ETopology topology)

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -5,6 +5,9 @@
 #include "Chunks/MSH/MSH.h"
 #include "Wrappers/Level.h"
 
+#include <iostream>
+#define COUT(x) std::cout << x << std::endl
+
 namespace LibSWBF2
 {
 #define CheckPtr(obj, ret) if (obj == nullptr) { LOG_ERROR("[API] Given Pointer was NULL!"); return ret; }
@@ -169,11 +172,10 @@ namespace LibSWBF2
 		primsList = model -> GetCollisionPrimitives((ECollisionMaskFlags) mask);
 		primPtrs.Clear();
 
-		for (size_t i = 0; i < primsList.Size(); ++i)
+		for (size_t i = 0; i < primsList.Size(); i++)
 		{
 			primPtrs.Add(&primsList[i]);
 		}		
-
 
 		primArrayPtr = primPtrs.GetArrayPtr();
 		numPrims = (uint32_t) primPtrs.Size();		
@@ -227,14 +229,24 @@ namespace LibSWBF2
 
     const void CollisionPrimitive_FetchAllFields(CollisionPrimitive *primPtr,
                                             float_t& f1, float_t& f2, float_t& f3,
-                                            const char *& name, const char *& parentName,
+                                            const char *& namePtr, const char *& parentNamePtr,
                                             uint32_t& maskFlags, uint32_t& primitiveType,
                                             const Vector3*& pos, const Vector4*& rot)
     {
     	f1 = f2 = f3 = 0.0f;
 
-    	name = primPtr -> GetName().Buffer();
-    	parentName = primPtr -> GetParentName().Buffer();
+    	COUT("Is null? " << (primPtr == nullptr));
+    	//COUT("Prim name: " << primPtr -> GetName().Buffer());
+
+    	const String& name = primPtr -> GetName();
+    	const String& parentName = primPtr -> GetParentName();
+
+    	COUT("Set namez");
+
+    	namePtr = name.Buffer();
+    	parentNamePtr = parentName.Buffer();
+
+    	COUT("Set name ptrs");
 
     	maskFlags = (uint32_t) primPtr -> GetMaskFlags();
     	primitiveType = (uint32_t) primPtr -> GetPrimitiveType();
@@ -259,7 +271,7 @@ namespace LibSWBF2
     }
 
 
-    
+
     const void Vector4_FromPtr(const Vector4* vec, float& x, float& y, float& z, float &w)
     {
     	x = vec -> m_X;

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -6,8 +6,6 @@
 #include "Wrappers/Level.h"
 #include "Wrappers/Terrain.h"
 
-#include <iostream>
-#define COUT(x) std::cout << x << std::endl
 
 namespace LibSWBF2
 {

--- a/LibSWBF2/API.h
+++ b/LibSWBF2/API.h
@@ -15,12 +15,22 @@ namespace LibSWBF2
 		class Segment;
 		class CollisionMesh;
 		struct Bone;
+		class CollisionPrimitive;
 		//class Texture;
 		//class World;
 		//class Terrain;
 		//class Script;
 	}
+
+
+	namespace Types
+	{
+		struct Vector4;
+		struct Vector3;
+	}
+
 	using namespace Wrappers;
+	using namespace Types;
 
 	// Provide mangling free C-functions to be accessible from C# wrapper
 	extern "C"
@@ -59,7 +69,8 @@ namespace LibSWBF2
 		LIBSWBF2_API uint8_t Model_IsSkeletalMesh(const Model* model);
 		LIBSWBF2_API uint8_t Model_GetSkeleton(const Model* model, Bone*& boneArr, uint32_t& boneCount);
 		LIBSWBF2_API const CollisionMesh* Model_GetCollisionMesh(const Model *model);
-
+		LIBSWBF2_API const void Model_GetPrimitivesMasked(const Model* model, uint32_t mask, int& numPrims,
+														CollisionPrimitive**& primArrayPtr);
 
 		// Wrappers - Segment
 		// ....
@@ -68,7 +79,12 @@ namespace LibSWBF2
 		LIBSWBF2_API const void CollisionMesh_GetIndexBuffer(const CollisionMesh *collMesh, uint32_t& count, int*& buffer);
         LIBSWBF2_API const void CollisionMesh_GetVertexBuffer(const CollisionMesh *collMesh, uint32_t& count, float_t*& buffer);
 
-
+        // Wrappers - CollisionPrimitive
+        LIBSWBF2_API const void CollisionPrimitive_FetchAllFields(CollisionPrimitive *primPtr,
+                                                    float_t& f1, float_t& f2, float_t& f3,
+                                                    const char *& name, const char *& parentName,
+                                                    uint32_t& maskFlags, uint32_t& primitiveType,
+                                                    const Vector3*& pos, const Vector4*& rot);
 
 		// Enums
 		LIBSWBF2_API const char* ENUM_TopologyToString(ETopology topology);

--- a/LibSWBF2/API.h
+++ b/LibSWBF2/API.h
@@ -90,5 +90,11 @@ namespace LibSWBF2
 		LIBSWBF2_API const char* ENUM_TopologyToString(ETopology topology);
 		LIBSWBF2_API const char* ENUM_MaterialFlagsToString(EMaterialFlags flags);
 		LIBSWBF2_API const char* ENUM_VBUFFlagsToString(EVBUFFlags flags);
+
+
+		// Wrappers - Vectors
+		LIBSWBF2_API const void Vector4_FromPtr(const Vector4* vec, float_t& x, float_t& y, float_t& z, float_t &w);        
+		LIBSWBF2_API const void Vector3_FromPtr(const Vector3* vec, float_t& x, float_t& y, float_t& z); 
+		LIBSWBF2_API const void Vector2_FromPtr(const Vector2* vec, float_t& x, float_t& y); 
 	}
 }

--- a/LibSWBF2/API.h
+++ b/LibSWBF2/API.h
@@ -84,7 +84,7 @@ namespace LibSWBF2
                                                     float_t& f1, float_t& f2, float_t& f3,
                                                     const char *& name, const char *& parentName,
                                                     uint32_t& maskFlags, uint32_t& primitiveType,
-                                                    const Vector3*& pos, const Vector4*& rot);
+                                                    Vector3*& pos, Vector4*& rot);
 
 		// Enums
 		LIBSWBF2_API const char* ENUM_TopologyToString(ETopology topology);

--- a/LibSWBF2/Chunks/LVL/prim/prim.DATA.cpp
+++ b/LibSWBF2/Chunks/LVL/prim/prim.DATA.cpp
@@ -47,6 +47,9 @@ namespace LibSWBF2::Chunks::LVL::prim
 			case ECollisionPrimitiveType::Cube:
 				return fmt::format("Type: Cube, x: {}, y: {}, z: {}",
 									m_Field1, m_Field2, m_Field3).c_str();
+			case ECollisionPrimitiveType::Empty:
+				return "Empty";
+				
 			default:
 				String unknown = CollisionPrimitiveTypeToString(m_PrimitiveType);
 				return fmt::format("{}, field1: {}, field2: {}, field3: {}",

--- a/LibSWBF2/Types/Enums.cpp
+++ b/LibSWBF2/Types/Enums.cpp
@@ -346,6 +346,11 @@ namespace LibSWBF2
 			return "Cube";
 		}
 
+		if (type == ECollisionPrimitiveType::Empty)
+		{
+			return "Empty";
+		}
+
 		return fmt::format("Unknown Collision Primitive Type: {}", (uint32_t) type).c_str();
 	}
 

--- a/LibSWBF2/Types/Enums.h
+++ b/LibSWBF2/Types/Enums.h
@@ -107,6 +107,7 @@ namespace LibSWBF2
 	{
 		Sphere = 1,//can also be 0...
 		Cylinder = 2,
+		Empty = 3, //not confirmed in documentation read so far 
 		Cube = 4,
 	};
 

--- a/LibSWBF2/Types/List.cpp
+++ b/LibSWBF2/Types/List.cpp
@@ -519,8 +519,11 @@ namespace LibSWBF2
 	template class LIBSWBF2_API Types::List<Wrappers::EntityClass>;
 	template class LIBSWBF2_API Types::List<Wrappers::CollisionPrimitive>;
 
+	template class LIBSWBF2_API Types::List<Wrappers::CollisionPrimitive*>;
+
 	template class LIBSWBF2_API Types::List<const Wrappers::World*>;
 	template class LIBSWBF2_API Types::List<const Wrappers::Texture*>;
 	template class LIBSWBF2_API Types::List<const Wrappers::Model*>;
 	template class LIBSWBF2_API Types::List<const Wrappers::Localization*>;
+	template class LIBSWBF2_API Types::List<const Wrappers::CollisionPrimitive*>;
 }

--- a/LibSWBF2/Wrappers/CollisionPrimitive.cpp
+++ b/LibSWBF2/Wrappers/CollisionPrimitive.cpp
@@ -28,22 +28,22 @@ namespace LibSWBF2::Wrappers
                                      p_ParentChunk(parent), p_FieldsChunk(fields) {}
 
 
-    const Vector4& CollisionPrimitive::GetRotation() const
+    Vector4 CollisionPrimitive::GetRotation() const
     {
         return MatrixToQuaternion(p_TransformChunk -> m_RotationMatrix);
     }
 
-    const Vector3& CollisionPrimitive::GetPosition() const
+    Vector3 CollisionPrimitive::GetPosition() const
     {
         return p_TransformChunk -> m_Position;
     }
 
-    const String& CollisionPrimitive::GetName() const
+    String CollisionPrimitive::GetName() const
     {
         return p_NameChunk -> ToString();
     }
 
-    const String& CollisionPrimitive::GetParentName() const
+    String CollisionPrimitive::GetParentName() const
     {
         return p_ParentChunk -> ToString();
     }

--- a/LibSWBF2/Wrappers/CollisionPrimitive.cpp
+++ b/LibSWBF2/Wrappers/CollisionPrimitive.cpp
@@ -28,19 +28,24 @@ namespace LibSWBF2::Wrappers
                                      p_ParentChunk(parent), p_FieldsChunk(fields) {}
 
 
-    Vector4 CollisionPrimitive::GetRotation() const
+    const Vector4& CollisionPrimitive::GetRotation() const
     {
         return MatrixToQuaternion(p_TransformChunk -> m_RotationMatrix);
     }
 
-    Vector3 CollisionPrimitive::GetPosition() const
+    const Vector3& CollisionPrimitive::GetPosition() const
     {
         return p_TransformChunk -> m_Position;
     }
 
-    String CollisionPrimitive::GetName() const
+    const String& CollisionPrimitive::GetName() const
     {
         return p_NameChunk -> ToString();
+    }
+
+    const String& CollisionPrimitive::GetParentName() const
+    {
+        return p_ParentChunk -> ToString();
     }
 
     ECollisionPrimitiveType CollisionPrimitive::GetPrimitiveType() const

--- a/LibSWBF2/Wrappers/CollisionPrimitive.h
+++ b/LibSWBF2/Wrappers/CollisionPrimitive.h
@@ -42,10 +42,11 @@ namespace LibSWBF2::Wrappers
                            DATA_PRIM *fields, CollisionPrimitive& out);
 	public:
 		
-		String GetName() const;
+		const String& GetName() const;
+		const String& GetParentName() const;
 
-		Vector4 GetRotation() const;
-		Vector3 GetPosition() const;
+		const Vector4& GetRotation() const;
+		const Vector3& GetPosition() const;
 
 		ECollisionPrimitiveType GetPrimitiveType() const;
 		ECollisionMaskFlags GetMaskFlags() const;

--- a/LibSWBF2/Wrappers/CollisionPrimitive.h
+++ b/LibSWBF2/Wrappers/CollisionPrimitive.h
@@ -42,11 +42,11 @@ namespace LibSWBF2::Wrappers
                            DATA_PRIM *fields, CollisionPrimitive& out);
 	public:
 		
-		const String& GetName() const;
-		const String& GetParentName() const;
+		String GetName() const;
+		String GetParentName() const;
 
-		const Vector4& GetRotation() const;
-		const Vector3& GetPosition() const;
+		Vector4 GetRotation() const;
+		Vector3 GetPosition() const;
 
 		ECollisionPrimitiveType GetPrimitiveType() const;
 		ECollisionMaskFlags GetMaskFlags() const;


### PR DESCRIPTION
Updates to Collision API
- ```Empty``` (3) collision primitive type
- ```CollisionPrimitive``` C# wrapper (relies off of single getter which fetches all fields at once from a given native pointer) 
- Other updates to C# API, Vector-from-native-pointer constructors added 