### PR TITLE
MNAM chunks + new Tag member for Segment wrapper

### DIFF
--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -158,7 +158,7 @@ namespace LibSWBF2
 
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool Segment_FetchAllFields(IntPtr seg, [MarshalAs(UnmanagedType.U1)] out bool pretx, out IntPtr boneName, out IntPtr MNAM,
+        public static extern bool Segment_FetchAllFields(IntPtr seg, [MarshalAs(UnmanagedType.U1)] out bool pretx, out IntPtr boneName, out IntPtr tag,
                                                         out uint numVerts, out IntPtr pBuf, out IntPtr nBuf, out IntPtr uvBuf,
                                                         out uint numVWs, out IntPtr vwBuf,
                                                         out int topo, out uint numInds, out IntPtr iBuf,

--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -158,7 +158,7 @@ namespace LibSWBF2
 
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool Segment_FetchAllFields(IntPtr seg, [MarshalAs(UnmanagedType.U1)] out bool pretx, out IntPtr boneName,
+        public static extern bool Segment_FetchAllFields(IntPtr seg, [MarshalAs(UnmanagedType.U1)] out bool pretx, out IntPtr boneName, out IntPtr MNAM,
                                                         out uint numVerts, out IntPtr pBuf, out IntPtr nBuf, out IntPtr uvBuf,
                                                         out uint numVWs, out IntPtr vwBuf,
                                                         out int topo, out uint numInds, out IntPtr iBuf,

--- a/LibSWBF2.NET/Wrappers/Segment.cs
+++ b/LibSWBF2.NET/Wrappers/Segment.cs
@@ -22,7 +22,7 @@ namespace LibSWBF2.Wrappers
     {
         public ETopology Topology { get; private set; }
         public string   BoneName { get; private set; }
-        public string   MNAM { get; private set; }
+        public string   Tag { get; private set; }
         public bool     IsPretransformed { get; private set; }
         public int      NumVertices { get; private set; }
         public int      NumIndices { get; private set; }
@@ -38,7 +38,7 @@ namespace LibSWBF2.Wrappers
         internal override void SetPtr(IntPtr seg)
         {
             base.SetPtr(seg);
-            if (APIWrapper.Segment_FetchAllFields(seg, out bool isPretransformed, out IntPtr boneNamePtr, out IntPtr MNAMPtr,
+            if (APIWrapper.Segment_FetchAllFields(seg, out bool isPretransformed, out IntPtr boneNamePtr, out IntPtr tagPtr,
                                                         out uint numVertsOut, out VertexBufferPtr, out NormalsBufferPtr, out UVBufferPtr,
                                                         out uint numVWsOut, out VertexWeightsBufferPtr,
                                                         out int topo, out uint numIndsOut, out IndexBufferPtr,
@@ -49,7 +49,7 @@ namespace LibSWBF2.Wrappers
                 NumVertices = (int) numVertsOut;
                 NumVertexWeights = (int) numVWsOut;
                 BoneName = Marshal.PtrToStringAnsi(boneNamePtr);
-                MNAM = Marshal.PtrToStringAnsi(MNAMPtr);
+                Tag = Marshal.PtrToStringAnsi(tagPtr);
 
                 Topology = (ETopology) topo;
                 Material = FromNative<Material>(matPtr);

--- a/LibSWBF2.NET/Wrappers/Segment.cs
+++ b/LibSWBF2.NET/Wrappers/Segment.cs
@@ -22,6 +22,7 @@ namespace LibSWBF2.Wrappers
     {
         public ETopology Topology { get; private set; }
         public string   BoneName { get; private set; }
+        public string   MNAM { get; private set; }
         public bool     IsPretransformed { get; private set; }
         public int      NumVertices { get; private set; }
         public int      NumIndices { get; private set; }
@@ -37,7 +38,7 @@ namespace LibSWBF2.Wrappers
         internal override void SetPtr(IntPtr seg)
         {
             base.SetPtr(seg);
-            if (APIWrapper.Segment_FetchAllFields(seg, out bool isPretransformed, out IntPtr boneNamePtr,
+            if (APIWrapper.Segment_FetchAllFields(seg, out bool isPretransformed, out IntPtr boneNamePtr, out IntPtr MNAMPtr,
                                                         out uint numVertsOut, out VertexBufferPtr, out NormalsBufferPtr, out UVBufferPtr,
                                                         out uint numVWsOut, out VertexWeightsBufferPtr,
                                                         out int topo, out uint numIndsOut, out IndexBufferPtr,
@@ -48,6 +49,8 @@ namespace LibSWBF2.Wrappers
                 NumVertices = (int) numVertsOut;
                 NumVertexWeights = (int) numVWsOut;
                 BoneName = Marshal.PtrToStringAnsi(boneNamePtr);
+                MNAM = Marshal.PtrToStringAnsi(MNAMPtr);
+
                 Topology = (ETopology) topo;
                 Material = FromNative<Material>(matPtr);
             }

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -581,14 +581,14 @@ namespace LibSWBF2
     
 
     //Wrappers - Segment
-    const uint8_t Segment_FetchAllFields(const Segment* seg, uint8_t& pretx, const char *&boneName, const char *&MNAM,
+    const uint8_t Segment_FetchAllFields(const Segment* seg, uint8_t& pretx, const char *&boneName, const char *&tag,
 														uint32_t& numVerts, Vector3*& pBuf, Vector3*& nBuf, Vector2*&uvBuf,
 														uint32_t& numVWs, VertexWeight*& vwBuf,
 														int32_t& topo, uint32_t& numInds, uint16_t*& iBuf,
 														const Material*& mat)
     {
     	static String boneNameCache;
-    	static String MNAMCache;
+    	static String tagCache;
 
     	CheckPtr(seg, false);
 
@@ -597,8 +597,8 @@ namespace LibSWBF2
     	boneNameCache = seg -> GetBone();
     	boneName = boneNameCache.Buffer();
 
-    	MNAMCache = seg -> GetMNAM();
-    	MNAM = MNAMCache.Buffer();
+    	tagCache = seg -> GetTag();
+    	tag = tagCache.Buffer();
 
     	//Handle vertex buffers
     	uint32_t numNormals, numUVs;

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -581,19 +581,24 @@ namespace LibSWBF2
     
 
     //Wrappers - Segment
-    const uint8_t Segment_FetchAllFields(const Segment* seg, uint8_t& pretx, const char *&boneName,
+    const uint8_t Segment_FetchAllFields(const Segment* seg, uint8_t& pretx, const char *&boneName, const char *&MNAM,
 														uint32_t& numVerts, Vector3*& pBuf, Vector3*& nBuf, Vector2*&uvBuf,
 														uint32_t& numVWs, VertexWeight*& vwBuf,
 														int32_t& topo, uint32_t& numInds, uint16_t*& iBuf,
 														const Material*& mat)
     {
     	static String boneNameCache;
+    	static String MNAMCache;
+
     	CheckPtr(seg, false);
 
     	pretx = seg -> IsPretransformed();
     	
     	boneNameCache = seg -> GetBone();
     	boneName = boneNameCache.Buffer();
+
+    	MNAMCache = seg -> GetMNAM();
+    	MNAM = MNAMCache.Buffer();
 
     	//Handle vertex buffers
     	uint32_t numNormals, numUVs;

--- a/LibSWBF2/API.h
+++ b/LibSWBF2/API.h
@@ -123,7 +123,7 @@ namespace LibSWBF2
 		LIBSWBF2_API const void Bone_FetchAllFields(const Bone* bone, const char *&name, const char *& parentName, const Vector3*& loc, const Vector4*& rot);
 
 		// Wrappers - Segment		
-		LIBSWBF2_API const uint8_t Segment_FetchAllFields(const Segment* seg, uint8_t& pretx, const char *&boneName, const char *&MNAM,
+		LIBSWBF2_API const uint8_t Segment_FetchAllFields(const Segment* seg, uint8_t& pretx, const char *&boneName, const char *&tag,
 														uint32_t& numVerts, Vector3*& pBuf, Vector3*& nBuf, Vector2*&uvBuf,
 														uint32_t& numVWs, VertexWeight*& vwBuf,
 														int32_t& topo, uint32_t& numInds, uint16_t*& iBuf, 

--- a/LibSWBF2/API.h
+++ b/LibSWBF2/API.h
@@ -123,10 +123,10 @@ namespace LibSWBF2
 		LIBSWBF2_API const void Bone_FetchAllFields(const Bone* bone, const char *&name, const char *& parentName, const Vector3*& loc, const Vector4*& rot);
 
 		// Wrappers - Segment		
-		LIBSWBF2_API const uint8_t Segment_FetchAllFields(const Segment* seg, uint8_t& pretx, const char *&boneName,
+		LIBSWBF2_API const uint8_t Segment_FetchAllFields(const Segment* seg, uint8_t& pretx, const char *&boneName, const char *&MNAM,
 														uint32_t& numVerts, Vector3*& pBuf, Vector3*& nBuf, Vector2*&uvBuf,
 														uint32_t& numVWs, VertexWeight*& vwBuf,
-														int32_t& topo, uint32_t& numInds, uint16_t*& iBuf,
+														int32_t& topo, uint32_t& numInds, uint16_t*& iBuf, 
 														const Material*& mat);
 
         // Wrappers - CollisionPrimitive

--- a/LibSWBF2/Chunks/GenericChunk.cpp
+++ b/LibSWBF2/Chunks/GenericChunk.cpp
@@ -369,6 +369,7 @@ namespace LibSWBF2::Chunks
 	template struct LIBSWBF2_API GenericChunk<"RTYP"_m>;
 	template struct LIBSWBF2_API GenericChunk<"BNAM"_m>;
 	template struct LIBSWBF2_API GenericChunk<"DTLX"_m>;
+	template struct LIBSWBF2_API GenericChunk<"MNAM"_m>;
 
 	// odf class types (see common/GenericCLass.cpp)
 	template struct LIBSWBF2_API GenericChunk<"entc"_m>;

--- a/LibSWBF2/Chunks/LVL/modl/modl.segm.cpp
+++ b/LibSWBF2/Chunks/LVL/modl/modl.segm.cpp
@@ -70,6 +70,10 @@ namespace LibSWBF2::Chunks::LVL::modl
                 READ_CHILD(stream, texture);
                 m_Textures.Add(texture);
             }
+            else if (next == "MNAM"_h)
+            {
+                READ_CHILD(stream, p_MNAM);
+            }
             else
             {
                 READ_CHILD_GENERIC(stream);

--- a/LibSWBF2/Chunks/LVL/modl/modl.segm.cpp
+++ b/LibSWBF2/Chunks/LVL/modl/modl.segm.cpp
@@ -72,7 +72,7 @@ namespace LibSWBF2::Chunks::LVL::modl
             }
             else if (next == "MNAM"_h)
             {
-                READ_CHILD(stream, p_MNAM);
+                READ_CHILD(stream, p_Tag);
             }
             else
             {

--- a/LibSWBF2/Chunks/LVL/modl/modl.segm.h
+++ b/LibSWBF2/Chunks/LVL/modl/modl.segm.h
@@ -21,7 +21,7 @@ namespace LibSWBF2::Chunks::LVL::modl
 		STR<"RTYP"_m>* p_RenderType;	// string seems to represent an enum
 		IBUF* p_IndexBuffer;
 		STR<"BNAM"_m>* p_Parent;
-		STR<"MNAM"_m>* p_MNAM; 			// Still don't know MNAM this means, ModelName???
+		STR<"MNAM"_m>* p_Tag; 			// Still don't know MNAM this means, ModelName???
 		SKIN* p_Skin;					// OPTIONAL
 		BMAP* p_BoneMap;				// OPTIONAL. This mapper seems unnecessary to me...
 

--- a/LibSWBF2/Chunks/LVL/modl/modl.segm.h
+++ b/LibSWBF2/Chunks/LVL/modl/modl.segm.h
@@ -21,6 +21,7 @@ namespace LibSWBF2::Chunks::LVL::modl
 		STR<"RTYP"_m>* p_RenderType;	// string seems to represent an enum
 		IBUF* p_IndexBuffer;
 		STR<"BNAM"_m>* p_Parent;
+		STR<"MNAM"_m>* p_MNAM; 			// Still don't know MNAM this means, ModelName???
 		SKIN* p_Skin;					// OPTIONAL
 		BMAP* p_BoneMap;				// OPTIONAL. This mapper seems unnecessary to me...
 

--- a/LibSWBF2/Chunks/STR.cpp
+++ b/LibSWBF2/Chunks/STR.cpp
@@ -82,6 +82,7 @@ namespace LibSWBF2::Chunks
 	template struct LIBSWBF2_API STR<"DTLX"_m>;
 	template struct LIBSWBF2_API STR<"BASE"_m>;
 	template struct LIBSWBF2_API STR<"PROP"_m>;
+	template struct LIBSWBF2_API STR<"MNAM"_m>;
 
 	template struct LIBSWBF2_API STR<"INFO"_m>;
 }

--- a/LibSWBF2/Wrappers/Segment.cpp
+++ b/LibSWBF2/Wrappers/Segment.cpp
@@ -196,11 +196,11 @@ namespace LibSWBF2::Wrappers
 	}
 
 
-	String Segment::GetMNAM() const
+	String Segment::GetTag() const
 	{
-		if (p_Segment -> p_MNAM != nullptr)
+		if (p_Segment -> p_Tag != nullptr)
 		{
-			return p_Segment -> p_MNAM -> m_Text;			
+			return p_Segment -> p_Tag -> m_Text;			
 		}
 
 		return "";

--- a/LibSWBF2/Wrappers/Segment.cpp
+++ b/LibSWBF2/Wrappers/Segment.cpp
@@ -196,6 +196,17 @@ namespace LibSWBF2::Wrappers
 	}
 
 
+	String Segment::GetMNAM() const
+	{
+		if (p_Segment -> p_MNAM != nullptr)
+		{
+			return p_Segment -> p_MNAM -> m_Text;			
+		}
+
+		return "";
+	}
+
+
 	bool Segment::IsPretransformed() const
 	{
 		auto flags = p_VertexBuffer -> m_Flags;

--- a/LibSWBF2/Wrappers/Segment.h
+++ b/LibSWBF2/Wrappers/Segment.h
@@ -75,6 +75,12 @@ namespace LibSWBF2::Wrappers
 		// returns the skeleton bone this segment belongs to
 		String GetBone() const;
 
+		// still not sure what the MNAM chunk refers to, seems pretty similar
+		// to p_Parent in that it connects a segment to a node/bone; however
+		// it does so with skinned segments, which is unusual...
+		String GetMNAM() const;
+
+		// Some weighted VBUF data is pre-transformed to zeroed bone transforms
 		bool IsPretransformed() const;
 	};
 }

--- a/LibSWBF2/Wrappers/Segment.h
+++ b/LibSWBF2/Wrappers/Segment.h
@@ -75,10 +75,10 @@ namespace LibSWBF2::Wrappers
 		// returns the skeleton bone this segment belongs to
 		String GetBone() const;
 
-		// still not sure what the MNAM chunk refers to, seems pretty similar
-		// to p_Parent in that it connects a segment to a node/bone; however
-		// it does so with skinned segments, which is unusual...
-		String GetMNAM() const;
+		// Used to indicate special meaning. Two known uses are for 
+		// indicating override_texture capability and scrolling
+		// wheel textures a la snailtank
+		String GetTag() const;
 
 		// Some weighted VBUF data is pre-transformed to zeroed bone transforms
 		bool IsPretransformed() const;


### PR DESCRIPTION
```Tag```s are mark a segment for special, ODF-referenced meaning. Two known uses are for indicating an overridable texture and dynamically scrolling textures a la snailtank/hailfire wheels.