### PR TITLE
Misc changes to C# tests and important change to CollisionMesh wrapper

### DIFF
--- a/LibSWBF2.NET.Test/LibSWBF2.NET.Test.csproj
+++ b/LibSWBF2.NET.Test/LibSWBF2.NET.Test.csproj
@@ -66,7 +66,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="testScripts.cs" />
+    <Compile Include="testCollision.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestBench.cs" />
   </ItemGroup>

--- a/LibSWBF2.NET.Test/TestBench.cs
+++ b/LibSWBF2.NET.Test/TestBench.cs
@@ -55,6 +55,23 @@ namespace LibSWBF2.NET.Test
         }
 
 
+        public Container LoadAndTrackContainer(string path, out Level levelOut)
+        {
+            Container c = LoadAndTrackContainer(new List<string>() { path }, out List<Level> levelsOut);
+            if (levelsOut.Count == 0)
+            {
+                levelOut = null;
+            }
+            else
+            {
+                levelOut = levelsOut[0];
+            }
+
+            return c;
+        }
+
+
+
         public Container LoadAndTrackContainer(List<string> paths, out List<Level> levelsOut)
         {
             Container container = new Container();

--- a/LibSWBF2.NET.Test/testCollision.cs
+++ b/LibSWBF2.NET.Test/testCollision.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using LibSWBF2.Logging;
 using LibSWBF2.Wrappers;
 using LibSWBF2.Types;
+using LibSWBF2.Enums;
 
 namespace LibSWBF2.NET.Test
 {
@@ -16,9 +17,12 @@ namespace LibSWBF2.NET.Test
     {
         static int Main(string[] args)
         {
-            TestBench.StartLogging(ELogType.Warning);
+            TestBench testBench = new TestBench();
 
-            var lvls = TestBench.LoadAndTrackLVLs(new List<string>(args));
+            Container container = testBench.LoadAndTrackContainer(new List<string>(args), out List<Level> lvls);
+
+
+            //var lvls = testBench.LoadAndTrackLVLs(new List<string>(args));
 
             for (int i = 0; i < lvls.Count; i++)
             {
@@ -26,30 +30,28 @@ namespace LibSWBF2.NET.Test
 
                 var level = lvls[i];
 
-                Model[] models = level.GetModels();
+                Model[] models = level.Get<Model>();
                 foreach (Model model in models)
                 {
-                    Console.WriteLine("\n\tModel: " + model.name);
+                    Console.WriteLine("\n\tModel: " + model.Name);
                     CollisionMesh mesh = model.GetCollisionMesh();
 
                     if (mesh == null) continue;
 
-                    Console.WriteLine("\t\tCollision mask flags: {0}", mesh.maskFlags);
+                    Console.WriteLine("\t\tCollision mask flags: {0}", mesh.MaskFlags);
                     Console.WriteLine("\t\tNum collision indices:   {0}", mesh.GetIndices().Length);
                     Console.WriteLine("\t\tNum collision verticies: {0}", mesh.GetVertices<Vector3>().Length);
                 
-                    CollisionPrimitive[] prims = model.GetPrimitivesMasked(16);
+                    CollisionPrimitive[] prims = model.GetPrimitivesMasked((ECollisionMaskFlags) 16);
 
                     Console.WriteLine("\t\t{0} Primitives: ", prims.Length);
 
                     foreach (var prim in prims)
                     {
-                        Console.WriteLine("\t\t\tName: {0} Parent: {1}", prim.name, prim.parentName);
+                        Console.WriteLine("\t\t\tName: {0} Parent: {1}", prim.Name, prim.ParentName);
                     }
                 }
             }
-
-            TestBench.StopLogging();
 
             return 0;
         }

--- a/LibSWBF2.NET.Test/testModelSegments.cs
+++ b/LibSWBF2.NET.Test/testModelSegments.cs
@@ -19,10 +19,8 @@ namespace LibSWBF2.NET.Test
         {            
             TestBench testBench = new TestBench();
 
-            Container container = testBench.LoadAndTrackContainer(new List<string>(args), out List<Level> levels);
+            Container container = testBench.LoadAndTrackContainer(args[0], out Level level);
 
-
-            Level level = levels[0];
             if (level == null) return -1;
             
             Model[] models = level.Get<Model>();
@@ -32,26 +30,29 @@ namespace LibSWBF2.NET.Test
             {   
                 Console.WriteLine("\n" + model.Name + ": ");
 
-                /*
-                if (model.isSkeletonBroken)
+                //if (model.Name != args[1]) continue;
+
+
+                
+                if (model.IsSkeletonBroken)
                 {
                     Console.WriteLine("\tSkeleton is broken!!");
                 }
 
                 Console.WriteLine("\tSkeleton: ");
-                
-                Bone[] bones = model.skeleton;
-
-                for (int k = 0; k < bones.Length; k++)
+                foreach (Bone bone in model.Skeleton)
                 {
-                    Console.WriteLine("\t\tName: {0} Parent: {1}", bones[k].name, bones[k].parentName);
+                    Console.WriteLine("\t\tName: {0} Parent: {1}", bone.Name, bone.ParentName);
                 }
-                */
+                
                 
                 Segment[] segments = model.GetSegments(); 
                 int i = 0;
                 foreach (Segment seg in segments)
                 {
+                    string MNAM = seg.Tag;
+                    if (MNAM == "") continue;
+
                     
                     Console.WriteLine("\tSegment " + i++ + ": ");
                     float[] vBuf = seg.GetVertexBuffer<float>();                        
@@ -70,9 +71,18 @@ namespace LibSWBF2.NET.Test
                         Console.WriteLine("\t\t{0} weights ---- {1} vertices.", weights.Length, seg.GetVertexBufferLength());
                         Console.WriteLine("\t\tIs pretransformed: {0}", seg.IsPretransformed);
                     }
-                    else
+
+                    string bone = seg.BoneName;
+                    //string MNAM = seg.MNAM;
+
+                    if (bone != "")
                     {
-                        Console.WriteLine("\t\tSegment belongs to bone: {0}", seg.BoneName);
+                        Console.WriteLine("\t\tSegment belongs to bone: {0}", bone);
+                    }
+
+                    if (MNAM != "")
+                    {
+                        Console.WriteLine("\t\tSegment has MNAM: {0}", MNAM);
                     }
 
                     Material mat = seg.Material;

--- a/LibSWBF2.NET.Test/testScripts.cs
+++ b/LibSWBF2.NET.Test/testScripts.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+using LibSWBF2.Logging;
+using LibSWBF2.Wrappers;
+using LibSWBF2.Types;
+
+namespace LibSWBF2.NET.Test
+{
+    class ScriptsTest
+    {
+        static int Main(string[] args)
+        {               
+            var tb = new TestBench();
+
+            var c = tb.LoadAndTrackContainer(new List<string>(args), out List<Level> lvls);
+
+
+            Level level = lvls[0];
+            if (level == null)
+            {
+                return -1;
+            }
+        
+            var scripts = level.Get<Script>();
+
+            foreach (var script in scripts)
+            {
+                Console.WriteLine(script.Name);
+
+                if (script.GetData(out IntPtr data, out uint size))
+                {
+                    Console.WriteLine("    Size: " + size.ToString() + " bytes...");
+                }
+            } 
+
+            return 1;            
+        }
+    }
+}

--- a/LibSWBF2/InternalHelpers.cpp
+++ b/LibSWBF2/InternalHelpers.cpp
@@ -71,6 +71,39 @@ namespace LibSWBF2
 	template List<uint16_t> TriangleStripToTriangleList<uint16_t,uint16_t>(List<uint16_t>& indexBuffer, uint32_t offset);
 
 
+	template <typename V, typename T>
+	List<V> TriangleFanToTriangleList(List<T>& indexBuffer, uint32_t offset)
+	{
+		List<V> result;
+		V a,b,c;
+
+		if (indexBuffer.Size() < 3)
+		{
+			return result;
+		}
+
+		for (int i = 2; i < indexBuffer.Size(); i++)
+		{
+			a = indexBuffer[i-1] + (V) offset;
+			b = indexBuffer[i]   + (V) offset;
+			c = indexBuffer[0]   + (V) offset; 
+
+			if (a != b && b != c && a != c)	//Catch degenerate 
+			{
+				result.Add(a);
+				result.Add(b);
+				result.Add(c);
+			}
+		}
+
+		return result;
+	}
+
+	template List<uint32_t> TriangleFanToTriangleList<uint32_t,uint32_t>(List<uint32_t>& indexBuffer, uint32_t offset);
+	template List<uint32_t> TriangleFanToTriangleList<uint32_t,uint16_t>(List<uint16_t>& indexBuffer, uint32_t offset);
+	template List<uint16_t> TriangleFanToTriangleList<uint16_t,uint16_t>(List<uint16_t>& indexBuffer, uint32_t offset);
+
+
 
 	Vector4 MatrixToQuaternion(const Matrix3x3& matrix)
 	{

--- a/LibSWBF2/InternalHelpers.h
+++ b/LibSWBF2/InternalHelpers.h
@@ -36,6 +36,13 @@ namespace LibSWBF2
 	template <typename V, typename T>
 	List<V> TriangleStripToTriangleList(List<T>& indexBuffer, uint32_t offset=0);
 
+	// Convert an index buffer from Triangle Fan format to Triangle List format
+	// optional: offset is added to each individual index.
+	// (so far only used for collision mesh extraction)
+	template <typename V, typename T>
+	List<V> TriangleFanToTriangleList(List<T>& indexBuffer, uint32_t offset=0);
+
+
 	Vector4 MatrixToQuaternion(const Matrix3x3& matrix);
 
 	std::string ToLower(String name);

--- a/LibSWBF2/Wrappers/CollisionMesh.cpp
+++ b/LibSWBF2/Wrappers/CollisionMesh.cpp
@@ -54,7 +54,8 @@ namespace LibSWBF2::Wrappers
             
             for (int i = 0; i < leaves.Size(); i++)
             {
-                m_Indicies.Append(TriangleStripToTriangleList<uint16_t, uint16_t>(leaves[i] -> m_Indicies));
+                List<uint16_t>& leaf_fan = leaves[i] -> m_Indicies;
+                m_Indicies.Append(TriangleFanToTriangleList<uint16_t, uint16_t>(leaf_fan, 0));
             }
         }
 


### PR DESCRIPTION
Collision meshes were improperly imported because ```LEAF``` nodes were being interpreted as triangle strips when they are actually triangle fans.  ```TriangleFanToTriangleList``` helper added to ```InternalHelpers```