### PR TITLE
Misc changes

### DIFF
--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -317,7 +317,8 @@ namespace LibSWBF2
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool Material_FetchAllFields(IntPtr matPtr, out IntPtr specular,
                                 out IntPtr diffuse, out IntPtr texNames, out int numTexes,
-                                out IntPtr attachedLightName, out uint matFlags, out uint specExp);
+                                out IntPtr attachedLightName, out uint matFlags, out uint specExp,
+                                out uint param1, out uint param2);
 
 
 

--- a/LibSWBF2.NET/Types/Vector2.cs
+++ b/LibSWBF2.NET/Types/Vector2.cs
@@ -29,5 +29,10 @@ namespace LibSWBF2.Types
         {
             return "(" + X + ", " + Y + ")";
         }
+
+        public float Magnitude()
+        {
+            return (float) Math.Sqrt(X * X + Y * Y);
+        }
     }
 }

--- a/LibSWBF2.NET/Types/Vector3.cs
+++ b/LibSWBF2.NET/Types/Vector3.cs
@@ -25,5 +25,10 @@ namespace LibSWBF2.Types
         {
             return "(" + X + ", " + Y + ", " + Z + ")";
         }
+
+        public float Magnitude()
+        {
+            return (float) Math.Sqrt(X * X + Y * Y + Z * Z);
+        }
     }
 }

--- a/LibSWBF2.NET/Types/Vector4.cs
+++ b/LibSWBF2.NET/Types/Vector4.cs
@@ -26,5 +26,10 @@ namespace LibSWBF2.Types
         {
             return "(" + X + ", " + Y + ", " + Z + ", " + W + ")";
         }
+
+        public float Magnitude()
+        {
+            return (float) Math.Sqrt(X * X + Y * Y + Z * Z + W * W);
+        }
     }
 }

--- a/LibSWBF2.NET/Wrappers/Config.cs
+++ b/LibSWBF2.NET/Wrappers/Config.cs
@@ -104,59 +104,127 @@ namespace LibSWBF2.Wrappers
             return GetField(HashUtils.GetFNV(name));
         }
 
+        public bool GetField(string name, out Field fieldOut)
+        {
+            fieldOut = null;
+            CheckValidity();
+            fieldOut = GetField(name);
+            return fieldOut != null;
+        }
+
         public string GetString(string name)
+        {
+            GetString(name, out String r);
+            return r;
+        }
+
+        public bool GetString(string name, out string sOut)
         {
             CheckValidity();
             Field f = GetField(name);
+
             if (f == null)
             {
-                return "";
+                sOut = "";
+                return false;
             }
-            return f.GetString();
+            else 
+            {
+                sOut = f.GetString();
+                return true;
+            }
         }
 
         public float GetFloat(string name)
         {
+            GetFloat(name, out float r);
+            return r;
+        }
+
+        public bool GetFloat(string name, out float fOut)
+        {
             CheckValidity();
             Field f = GetField(name);
+
             if (f == null)
             {
-                return 0.0f;
+                fOut = 0f;
+                return false;
             }
-            return f.GetFloat();
+            else 
+            {
+                fOut = f.GetFloat();
+                return true;
+            }
         }
 
         public Vector2 GetVec2(string name)
         {
+            GetVec2(name, out Vector2 r);
+            return r;
+        }
+
+        public bool GetVec2(string name, out Vector2 vecOut)
+        {
             CheckValidity();
             Field f = GetField(name);
+
             if (f == null)
             {
-                return new Vector2();
+                vecOut = new Vector2();
+                return false;
             }
-            return f.GetVec2();
+            else 
+            {
+                vecOut = f.GetVec2();
+                return true;
+            }
         }
 
         public Vector3 GetVec3(string name)
         {
+            GetVec3(name, out Vector3 r);
+            return r;
+        }
+
+        public bool GetVec3(string name, out Vector3 vecOut)
+        {
             CheckValidity();
             Field f = GetField(name);
+
             if (f == null)
             {
-                return new Vector3();
+                vecOut = new Vector3();
+                return false;
             }
-            return f.GetVec3();
+            else 
+            {
+                vecOut = f.GetVec3();
+                return true;
+            }
         }
 
         public Vector4 GetVec4(string name)
         {
+            GetVec4(name, out Vector4 r);
+            return r;
+        }
+
+        public bool GetVec4(string name, out Vector4 vecOut)
+        {
             CheckValidity();
             Field f = GetField(name);
+
             if (f == null)
             {
-                return new Vector4();
+                vecOut = new Vector4();
+                return false;
             }
-            return f.GetVec4();
+            else 
+            {
+                vecOut = f.GetVec4();
+                return true;
+            }
         }
     }
 

--- a/LibSWBF2.NET/Wrappers/Material.cs
+++ b/LibSWBF2.NET/Wrappers/Material.cs
@@ -20,13 +20,18 @@ namespace LibSWBF2.Wrappers
         public Vector3       DiffuseColor { get; private set; }
         public string        AttachedLight { get; private set; }
 
+        public uint          Param1 { get; private set; }
+        public uint          Param2 { get; private set; }
+
+
         internal override void SetPtr(IntPtr ptr)
         {
             base.SetPtr(ptr);
             if (APIWrapper.Material_FetchAllFields(ptr, out IntPtr specular,
                                                 out IntPtr diffuse, out IntPtr texNames,
                                                 out int numTexes, out IntPtr attachedLightName,
-                                                out uint matFlags, out uint specularExponent))
+                                                out uint matFlags, out uint specularExponent,
+                                                out uint param1, out uint param2))
             {
                 MaterialFlags = (EMaterialFlags) matFlags;
 
@@ -36,6 +41,9 @@ namespace LibSWBF2.Wrappers
 
                 Textures = new ReadOnlyCollection<string>(MemUtils.IntPtrToStringList(texNames, numTexes));
                 AttachedLight = Marshal.PtrToStringAnsi(attachedLightName);
+
+                Param1 = param1;
+                Param2 = param2;
             }
         }
     }

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -629,7 +629,8 @@ namespace LibSWBF2
     // Wrappers - Material
     uint8_t Material_FetchAllFields(const Material* matPtr,  Vector3*& specular,
                     Vector3*& diffuse, char**& texPtrs, int32_t& numTexes,
-                    char*& attachedLightName, uint32_t& matFlags, uint32_t& specExp)
+                    char*& attachedLightName, uint32_t& matFlags, uint32_t& specExp,
+                    uint32_t& param1, uint32_t&param2)
     {	
     	static Vector3 specCache, diffCache;
     	static char** texNamePtrsCache = new char*[4];
@@ -658,6 +659,9 @@ namespace LibSWBF2
 
     	diffuse = &diffCache;
     	specular = &specCache; 
+
+    	param1 = matPtr -> GetFirstParameter();
+    	param2 = matPtr -> GetSecondParameter();
 
     	attachedLightName = const_cast<char *>(matPtr -> GetAttachedLight().Buffer());
 

--- a/LibSWBF2/API.h
+++ b/LibSWBF2/API.h
@@ -180,7 +180,8 @@ namespace LibSWBF2
         // Wrappers - Material
         LIBSWBF2_API uint8_t Material_FetchAllFields(const Material* matPtr,  Vector3*& specular,
                                 Vector3*& diffuse, char**& texPtrs, int32_t& numTexes,
-                                char*& attachedLightName, uint32_t& matFlags, uint32_t& specExp);
+                                char*& attachedLightName, uint32_t& matFlags, uint32_t& specExp,
+                                uint32_t& param1, uint32_t& param2);
 
 		// Wrappers - AnimationBank
 		LIBSWBF2_API const bool AnimationBank_GetCurve(const AnimationBank* setPtr, uint32_t animCRC, uint32_t boneCRC, uint32_t comp, 

--- a/LibSWBF2/Chunks/LVL/modl/MTRL.cpp
+++ b/LibSWBF2/Chunks/LVL/modl/MTRL.cpp
@@ -24,8 +24,8 @@ namespace LibSWBF2::Chunks::LVL::modl
         m_DiffuseColor.ReadFromStream(stream);
         m_SpecularColor.ReadFromStream(stream);
         m_SpecularExponent = stream.ReadUInt32();
-        m_Unknown[0] = stream.ReadUInt32();
-        m_Unknown[1] = stream.ReadUInt32();
+        m_Parameters[0] = stream.ReadUInt32();
+        m_Parameters[1] = stream.ReadUInt32();
         m_AttachedLight = stream.ReadString();
 
         BaseChunk::EnsureEnd(stream);

--- a/LibSWBF2/Chunks/LVL/modl/MTRL.h
+++ b/LibSWBF2/Chunks/LVL/modl/MTRL.h
@@ -12,7 +12,7 @@ namespace LibSWBF2::Chunks::LVL::modl
 		Color4u8 m_DiffuseColor;
 		Color4u8 m_SpecularColor;
 		uint32_t m_SpecularExponent;
-		uint32_t m_Unknown[2];
+		uint32_t m_Parameters[2];
 		String m_AttachedLight;
 
 	public:

--- a/LibSWBF2/DirectX/DXTexCrossPlat.cpp
+++ b/LibSWBF2/DirectX/DXTexCrossPlat.cpp
@@ -100,6 +100,9 @@ bool CrossPlatImage::ToRGBA(){
 
   if (!m_IsValid) return false;
 
+  if (format == D3DFMT_R8G8B8A8) return true;
+
+
   uint32_t* sink = new uint32_t[width * height]();
 
   switch (format){
@@ -137,6 +140,8 @@ bool CrossPlatImage::ToRGBA(){
 
   delete[] p_Data;
   p_Data = (uint8_t *) sink;
+
+  format = D3DFMT_R8G8B8A8;
 
   return true;
 }

--- a/LibSWBF2/Wrappers/Material.cpp
+++ b/LibSWBF2/Wrappers/Material.cpp
@@ -56,6 +56,16 @@ namespace LibSWBF2::Wrappers
 		return p_Material->m_SpecularExponent;
 	}
 
+	const uint32_t Material::GetFirstParameter() const
+	{	
+		return p_Material->m_Parameters[0];
+	}
+
+	const uint32_t Material::GetSecondParameter() const
+	{
+		return p_Material->m_Parameters[1];
+	}
+
 	const String& Material::GetAttachedLight() const
 	{
 		return p_Material->m_AttachedLight;

--- a/LibSWBF2/Wrappers/Material.h
+++ b/LibSWBF2/Wrappers/Material.h
@@ -51,5 +51,8 @@ namespace LibSWBF2::Wrappers
 
 		// will try to resolve within this Level
 		const Texture* GetTexture(uint8_t index) const;
+
+		const uint32_t GetFirstParameter() const;
+		const uint32_t GetSecondParameter() const;
 	};
 }


### PR DESCRIPTION
Miscellaneous changes including:
  - Added two ```uint32``` parameters in ```MTRL``` chunks.  Necessary ```Material``` wrapper methods/marshallers added.  Needed for scrolling textures among a few other things I imagine
  - ```Magnitude``` convenience methods added to C# vector wrappers
  - More convenient getters added to ```Config```/```Scope``` C# wrappers 
  - Fixed big bug in ```CrossPlatImage``` code that would return garbage when RGBA data was requested multiple times.  More important to include now that Windows specific code was nixed